### PR TITLE
fix(codex): count archived_sessions, not just the live sessions dir

### DIFF
--- a/src/native/codex.ts
+++ b/src/native/codex.ts
@@ -236,10 +236,25 @@ export function aggregateCodexSessions(
   return finalizeCodexEntries(acc);
 }
 
+/** Resolve the Codex home (honors CODEX_HOME, default ~/.codex). */
+function resolveCodexHome(env = process.env): string {
+  return env.CODEX_HOME && env.CODEX_HOME.trim() ? env.CODEX_HOME.trim() : join(homedir(), ".codex");
+}
+
 /** Resolve the Codex sessions root (honors CODEX_HOME, default ~/.codex). */
 export function resolveCodexSessionsDir(env = process.env): string {
-  const home = env.CODEX_HOME && env.CODEX_HOME.trim() ? env.CODEX_HOME.trim() : join(homedir(), ".codex");
-  return join(home, "sessions");
+  return join(resolveCodexHome(env), "sessions");
+}
+
+/**
+ * Every root holding Codex rollouts. Codex moves finished sessions out of
+ * `sessions/` into `archived_sessions/`, so reading only the live directory
+ * silently drops most of the history — on a heavy user that was 26 of 41 days.
+ * Both are scanned; a missing directory just yields no files.
+ */
+export function resolveCodexSessionsDirs(env = process.env): string[] {
+  const home = resolveCodexHome(env);
+  return [join(home, "sessions"), join(home, "archived_sessions")];
 }
 
 async function listJsonl(dir: string): Promise<string[]> {
@@ -327,8 +342,8 @@ export async function collectCodexNative(
   env = process.env,
   opts: { budgetMs?: number; now?: () => number; cachePath?: string } = {},
 ): Promise<NativeCollectResult> {
-  const dir = resolveCodexSessionsDir(env);
-  const files = await listJsonl(dir);
+  const dirs = resolveCodexSessionsDirs(env);
+  const files = (await Promise.all(dirs.map(listJsonl))).flat();
   if (files.length === 0) return { entries: [], found: false, filesScanned: 0 };
   const now = opts.now ?? Date.now;
   const res = await readFilesWithCache<CachedSession>({

--- a/test/native-cache.test.ts
+++ b/test/native-cache.test.ts
@@ -325,4 +325,33 @@ describe("codex native reader through the cache", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("codex: archived_sessions are counted alongside the live sessions dir", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "wbm-codexarchive-"));
+    try {
+      const live = join(dir, "sessions", "2026", "06", "12");
+      const archived = join(dir, "archived_sessions", "2026", "06", "10");
+      await mkdir(live, { recursive: true });
+      await mkdir(archived, { recursive: true });
+      await writeFile(
+        join(live, "rollout-live.jsonl"),
+        codexRollout("gpt-5.3-codex", [{ ts: "2026-06-12T12:00:00Z", input: 60, output: 40 }]),
+      );
+      // Codex migrates finished sessions here; before the fix this whole file
+      // was invisible and its day vanished from the report entirely.
+      await writeFile(
+        join(archived, "rollout-archived.jsonl"),
+        codexRollout("gpt-5.3-codex", [{ ts: "2026-06-10T12:00:00Z", input: 20, output: 10 }]),
+      );
+      const env = { CODEX_HOME: dir, WHOBURNEDMORE_CONFIG_DIR: dir } as NodeJS.ProcessEnv;
+      const out = await collectCodexNative(env, { budgetMs: 5000 });
+      expect(out.found).toBe(true);
+      expect(out.filesScanned).toBe(2);
+      const total = out.entries.reduce((s, e) => s + e.inputTokens + e.outputTokens, 0);
+      expect(total).toBe(130);
+      expect(new Set(out.entries.map((e) => e.date)).size).toBe(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/native-codex.test.ts
+++ b/test/native-codex.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateCodexSessions,
   parseCodexRollout,
   resolveCodexSessionsDir,
+  resolveCodexSessionsDirs,
 } from "../src/native/codex.js";
 
 const meta = (model: string) =>
@@ -139,5 +140,20 @@ describe("resolveCodexSessionsDir", () => {
   it("defaults to ~/.codex/sessions and honors CODEX_HOME", () => {
     expect(resolveCodexSessionsDir({} as NodeJS.ProcessEnv)).toMatch(/\.codex\/sessions$/);
     expect(resolveCodexSessionsDir({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv)).toBe("/custom/codex/sessions");
+  });
+});
+
+describe("resolveCodexSessionsDirs", () => {
+  it("covers both the live and the archived rollout roots", () => {
+    expect(resolveCodexSessionsDirs({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv)).toEqual([
+      "/custom/codex/sessions",
+      "/custom/codex/archived_sessions",
+    ]);
+  });
+
+  it("defaults to ~/.codex and keeps the live dir first", () => {
+    const dirs = resolveCodexSessionsDirs({} as NodeJS.ProcessEnv);
+    expect(dirs[0]).toMatch(/\.codex\/sessions$/);
+    expect(dirs[1]).toMatch(/\.codex\/archived_sessions$/);
   });
 });


### PR DESCRIPTION
## Problem

The native Codex reader resolves exactly one root:

```ts
export function resolveCodexSessionsDir(env = process.env): string {
  const home = env.CODEX_HOME?.trim() || join(homedir(), ".codex");
  return join(home, "sessions");
}
```

But Codex does not keep finished sessions there — it migrates them into `~/.codex/archived_sessions/`. Everything that has been archived is therefore invisible to the reader.

This is not a small edge: on my machine `sessions/` holds 164 files spanning 14 days, while `archived_sessions/` holds 2226 files spanning 37 days.

It gets amplified by `selectSourceEntries()`, which prefers the native reader whenever it returns entries and discards the ccusage result. ccusage *does* read both directories, so the fuller data was collected and then thrown away:

| | days | tokens |
|---|---|---|
| native reader (live dir only) | 15 | 5.09B |
| ccusage (both dirs) | 41 | 27.65B |

So ~26 days and ~22B tokens were missing from my submissions, and the dashboard undercounted Codex by roughly 5x.

## Fix

`collectCodexNative` now scans both roots.

- `resolveCodexSessionsDir` is left exactly as it was, so nothing that imports it changes behaviour.
- New `resolveCodexSessionsDirs` returns `[sessions, archived_sessions]`, live dir first.
- `listJsonl` already tolerates a missing directory (returns `[]`), so users with no archive are unaffected — same files, same results.

The per-file cache keys on path, and each rollout still folds additively, so archived files flow through the existing cache path with no semantic change.

## Tests

Added to `test/native-cache.test.ts`:

- `codex: archived_sessions are counted alongside the live sessions dir` — a rollout in each root, asserts both are read (`filesScanned === 2`), tokens sum across them, and both days appear.

Added to `test/native-codex.test.ts`:

- `resolveCodexSessionsDirs` covers both roots and honours `CODEX_HOME`.

`npm run lint` clean, `npm run build` fine.

## Note on the suite

`test/native-cache.test.ts > an appended transcript is re-read and the day's total updates` fails on `main` before this change (`expected 10 to be 35`) on Node 25.9.0, reproducibly across runs. It is unrelated to this PR and left untouched — happy to look at it separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)