### PR TITLE
fix(collect): give session/blocks their own timeout so payload.sessions stops coming back empty

### DIFF
--- a/src/collect.ts
+++ b/src/collect.ts
@@ -367,19 +367,36 @@ export function ccusageClaudeEnv(
   return { ...env, CLAUDE_CONFIG_DIR: resolveClaudeConfigRoots(env).join(",") };
 }
 
+/**
+ * A single source shouldn't be able to hang the whole run. 25s is plenty for a
+ * healthy local read of one agent's transcripts; a hung source gets killed and
+ * (if transient) retried once rather than stalling everything for minutes.
+ */
+const CCUSAGE_SOURCE_TIMEOUT_MS = 25_000;
+
+/**
+ * `session` and `blocks` are NOT per-source: each re-reads EVERY agent's
+ * transcripts in one child, so it does roughly the work of all the per-source
+ * children combined — while those 15+ children run concurrently against the
+ * same disk. On a large corpus 25s is therefore too small by construction: the
+ * call and its retry both timed out, runCcusage returned null, and
+ * payload.sessions stayed empty on every single run. Since per-day message
+ * counts reach the server only through sessions[].messageCount (DailyUsageEntry
+ * has no message field), dashboards showed "0 messages" indefinitely.
+ */
+const CCUSAGE_AGGREGATE_TIMEOUT_MS = 180_000;
+
 async function runCcusageOnce(
   cmd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
+  timeoutMs: number = CCUSAGE_SOURCE_TIMEOUT_MS,
 ): Promise<{ json: unknown | null; transient: boolean }> {
   try {
     const { stdout } = await execFileAsync(cmd, args, {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
-      // A single source shouldn't be able to hang the whole run. 25s is plenty
-      // for a healthy local read; a hung source gets killed and (if transient)
-      // retried once below rather than stalling everything for minutes.
-      timeout: 25_000,
+      timeout: timeoutMs,
       ...(env ? { env } : {}),
     });
     if (!stdout) return { json: null, transient: false };
@@ -404,12 +421,13 @@ async function runCcusage(
   cmd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
+  timeoutMs: number = CCUSAGE_SOURCE_TIMEOUT_MS,
 ): Promise<unknown | null> {
-  const first = await runCcusageOnce(cmd, args, env);
+  const first = await runCcusageOnce(cmd, args, env, timeoutMs);
   if (first.json !== null || !first.transient) return first.json;
   // One retry on a transient failure so a flaky source stays in the report
   // run-to-run (data consistency) rather than dropping out intermittently.
-  return (await runCcusageOnce(cmd, args, env)).json;
+  return (await runCcusageOnce(cmd, args, env, timeoutMs)).json;
 }
 
 /**
@@ -499,13 +517,23 @@ export async function collectAll(onProgress?: ProgressFn): Promise<CollectResult
 
   // Richer rollups, gathered once across all agents (ccusage aggregates them):
   // sessions power "most expensive conversations", blocks power "peak hours".
-  const sessionTask = runCcusage(cmd, [...prefixArgs, "session", "--json", "--offline"]).then(
+  const sessionTask = runCcusage(
+    cmd,
+    [...prefixArgs, "session", "--json", "--offline"],
+    undefined,
+    CCUSAGE_AGGREGATE_TIMEOUT_MS,
+  ).then(
     (json) => {
       tick();
       return json ? mapCcusageSessions(json) : [];
     },
   );
-  const blockTask = runCcusage(cmd, [...prefixArgs, "blocks", "--json", "--offline"]).then(
+  const blockTask = runCcusage(
+    cmd,
+    [...prefixArgs, "blocks", "--json", "--offline"],
+    undefined,
+    CCUSAGE_AGGREGATE_TIMEOUT_MS,
+  ).then(
     (json) => {
       tick();
       return json ? mapCcusageBlocks(json) : [];


### PR DESCRIPTION
## Problem

Every ccusage child shares one ceiling:

```ts
// A single source shouldn't be able to hang the whole run. 25s is plenty
// for a healthy local read; ...
timeout: 25_000,
```

The reasoning holds for the per-source calls — one agent's transcripts. But `session` and `blocks` are not per-source. Each re-reads **every** agent's transcripts in a single child, so one of them does roughly the combined work of all 15 per-source children — and it runs while those children are hammering the same disk.

So on a large corpus 25s is too small by construction. Measured here:

- `ccusage session` standing alone: **~23s** — already at the edge
- inside `collectAll`'s fan-out: overruns 25s on the initial call **and** the retry, every run

`runCcusage` then returns `null`, `mapCcusageSessions` gets nothing, and `payload.sessions` ends up empty on every single submission. I confirmed this on live processes, watching the session child get killed at the ceiling and its retry start.

### Why it matters beyond the missing sessions

Per-day message counts reach the server **only** via `sessions[].messageCount` paired with `lastActivity`. `DailyUsageEntry` has no message field at all. With sessions permanently empty, my dashboard showed **"MESSAGES 0"** indefinitely, no matter how much I coded — which is what sent me looking in the first place.

## Fix

Split the one constant into two, and thread an explicit timeout through `runCcusage`/`runCcusageOnce`:

- `CCUSAGE_SOURCE_TIMEOUT_MS = 25_000` — unchanged behaviour for the 15 per-source calls, keeping "not installed" fast.
- `CCUSAGE_AGGREGATE_TIMEOUT_MS = 180_000` — for `session` and `blocks` only.

The parameter defaults to the source timeout, so every existing call site keeps its current behaviour; only the two aggregate call sites opt in.

## Result

| | before | after |
|---|---|---|
| `payload.sessions` | 0 | **2541** |
| sessions active today | — | 99 |
| messages today | 0 | **2639** |
| full collect wall time | ~60s | **32s** |

The run got *faster*: previously ~50s went into two doomed session attempts (25s + 25s retry) that produced nothing.

## Risk

A genuinely hung `session`/`blocks` can now stall a run for up to 3 minutes instead of 50s. That seems clearly preferable to the current state, where the data is guaranteed to be dropped on any corpus large enough to matter, and it stays well inside the 15-minute background interval. Happy to dial the number down, or make it relative to source count, if you'd rather.

`npm run lint` clean, `npm test` unchanged apart from the pre-existing `native-cache.test.ts` failure on `main` (`an appended transcript is re-read...`, `expected 10 to be 35` on Node 25.9.0), which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)