### PR TITLE
fix(autosync): stop opting the launchd job into macOS I/O throttling

### DIFF
--- a/src/autosync.ts
+++ b/src/autosync.ts
@@ -177,9 +177,19 @@ ${envEntries}
        interval. Submits are idempotent server-side, so an extra run is safe. -->
   <key>RunAtLoad</key>
   <true/>
-  <!-- Be a good citizen: macOS schedules this with background priority. -->
+  <!-- Standard, NOT Background. ProcessType=Background opts the job into
+       macOS I/O throttling, which is disastrous for a job whose work is almost
+       entirely reading thousands of transcript files: a full collect measured
+       ~51s unthrottled vs ~197s throttled on the same machine. That blows past
+       the collector's own budgets (25s per ccusage child, 45s for the native
+       reader), so every source times out at once, entries comes back empty and
+       the tick submits nothing — it logged "Nothing to burn yet" on 206 of 473
+       runs (~44%) until this was changed. Nice=0 keeps CPU priority neighbourly
+       without throttling the reads. -->
   <key>ProcessType</key>
-  <string>Background</string>
+  <string>Standard</string>
+  <key>Nice</key>
+  <integer>0</integer>
   <key>StandardOutPath</key>
   <string>${xmlEscape(logPath)}</string>
   <key>StandardErrorPath</key>

--- a/test/autosync.test.ts
+++ b/test/autosync.test.ts
@@ -32,6 +32,16 @@ import {
 } from "../src/autosync.js";
 
 describe("buildLaunchdPlist", () => {
+  it("does not opt the job into macOS I/O throttling", () => {
+    // ProcessType=Background throttles disk reads, and this job is almost pure
+    // disk reading. Throttled, a full collect overruns the collector's own
+    // budgets (25s per ccusage child, 45s native) and the tick submits nothing.
+    const plist = buildLaunchdPlist(syncCommandArgs("/usr/local/bin/npm"));
+    expect(plist).toContain("<key>ProcessType</key>");
+    expect(plist).toContain("<string>Standard</string>");
+    expect(plist).not.toContain("<string>Background</string>");
+  });
+
   it("produces a launchd plist that runs the latest npm package on an interval", () => {
     const plist = buildLaunchdPlist(
       syncCommandArgs("/usr/local/bin/npm"),


### PR DESCRIPTION
## Problem

```xml
<!-- Be a good citizen: macOS schedules this with background priority. -->
<key>ProcessType</key>
<string>Background</string>
```

The intent is good, but `ProcessType=Background` does more than lower CPU priority — it opts the job into macOS **disk I/O throttling**. And this job's work is almost entirely reading thousands of transcript files.

Measured on one machine, same corpus, back to back:

| | full collect |
|---|---|
| normal priority | **~51s** |
| `ProcessType=Background` | **~197s** |

A ~4x penalty, against a collector whose own budgets are 25s per ccusage child and 45s for the native reader. So under any real load every source blows its budget at the same time, `entries` comes back empty, and the tick submits nothing while printing "Nothing to burn yet".

In my `sync.log` that happened on **206 of 473 runs (~44%)**. The visible symptom is just a dashboard that quietly sits hours behind — `lastSyncAt` stops moving and nothing in the log says why. I only found it because I went looking at process priorities.

## Fix

- `ProcessType` → `Standard`
- add `Nice=0`

`Nice=0` keeps the job from hogging CPU scheduling, which preserves the "good citizen" intent, without throttling the reads that are the actual work. Every 15 minutes this job runs for well under a minute.

## Verification

After switching, the same machine ran ticks of 62s / 65s / 68s / 72s, all `exit=0`, with zero "Nothing to burn yet" — versus a 44% miss rate before.

## Tests

Added `does not opt the job into macOS I/O throttling` to `test/autosync.test.ts`, asserting the plist contains `Standard` and not `Background`, so this cannot silently regress. Remaining 41 autosync tests pass unchanged.

`npm run lint` clean. `npm test` unchanged apart from the pre-existing `native-cache.test.ts` failure on `main` (`an appended transcript is re-read...`, Node 25.9.0), unrelated to this PR.

## Possibly related

Linux/systemd installs are unaffected — no equivalent throttling is set there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)