### PR TITLE
fix(cursor): estimate API cost when Cursor reports totalCents=0

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -5,6 +5,7 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { BlockEntry, DailyUsageEntry } from "./shared.js";
 import { localUsageDate } from "./native/usage-date.js";
+import { estimateCostUSD } from "./pricing.js";
 import { collectCursorViaTokscale } from "./tokscale.js";
 
 // Cursor doesn't write ccusage-readable local logs — its usage lives behind the
@@ -115,7 +116,17 @@ export function mapCursorEvents(events: CursorEvent[]): {
     const output = num(tu.outputTokens);
     const cacheWrite = num(tu.cacheWriteTokens);
     const cacheRead = num(tu.cacheReadTokens);
-    const cost = Math.max(0, (Number(tu.totalCents) || 0) / 100);
+    // Cursor reports totalCents=0 for subscription/included usage even when
+    // tokens are huge. Prefer billed cents when present; otherwise estimate
+    // API-equivalent cost from public model rates (same as Claude/Codex paths).
+    const billed = Math.max(0, (Number(tu.totalCents) || 0) / 100);
+    const estimated = estimateCostUSD(model, {
+      inputTokens: input,
+      outputTokens: output,
+      cacheCreationTokens: cacheWrite,
+      cacheReadTokens: cacheRead,
+    });
+    const cost = billed > 0 ? billed : estimated;
     const total = input + output + cacheWrite + cacheRead;
     if (total === 0 && cost === 0) continue;
 

--- a/src/pricing.ts
+++ b/src/pricing.ts
@@ -53,6 +53,8 @@ const FALLBACK_TIERS: Array<{ match: RegExp; row: PriceRow }> = [
   { match: /haiku/i, row: [1, 5, 1.25, 0.1] },
   { match: /gpt-4o|gpt-4\.1/i, row: [2.5, 10, 2.5, 1.25] },
   { match: /gpt-5|o[134](-|$)|codex/i, row: [1.25, 10, 1.25, 0.125] },
+  // Cursor's Composer family has no public LiteLLM row; treat like mid-tier GPT-5.
+  { match: /composer/i, row: [1.25, 10, 1.25, 0.125] },
   { match: /gemini.*flash/i, row: [0.3, 2.5, 0.3, 0.03] },
   { match: /gemini/i, row: [2, 12, 2, 0.2] },
   { match: /grok/i, row: [3, 15, 3, 0.75] },

--- a/src/tokscale.ts
+++ b/src/tokscale.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import type { DailyUsageEntry } from "./shared.js";
+import { estimateCostUSD } from "./pricing.js";
 
 // Fallback Cursor source: the community-maintained `tokscale` CLI. The primary
 // path (src/cursor.ts) calls Cursor's dashboard API directly; if Cursor changes
@@ -45,13 +46,23 @@ export function mapTokscaleDay(date: string, json: unknown): DailyUsageEntry[] {
     const outputTokens = num(e.output) + num(e.reasoning);
     const cacheCreationTokens = num(e.cacheWrite);
     const cacheReadTokens = num(e.cacheRead);
-    const costUSD = numCost(e.cost);
+    const model = typeof e.model === "string" && e.model ? e.model : "cursor";
+    const billed = numCost(e.cost);
+    const costUSD =
+      billed > 0
+        ? billed
+        : estimateCostUSD(model, {
+            inputTokens,
+            outputTokens,
+            cacheCreationTokens,
+            cacheReadTokens,
+          });
     const total = inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens;
     if (total === 0 && costUSD === 0) continue;
     out.push({
       date,
       tool: "cursor",
-      model: typeof e.model === "string" && e.model ? e.model : "cursor",
+      model,
       inputTokens,
       outputTokens,
       cacheCreationTokens,

--- a/test/cursor.test.ts
+++ b/test/cursor.test.ts
@@ -41,6 +41,40 @@ describe("mapCursorEvents", () => {
     expect(blocks[0].totalTokens).toBeGreaterThan(0);
   });
 
+  it("estimates API-equivalent cost when Cursor reports totalCents=0 (included usage)", () => {
+    const { entries } = mapCursorEvents([
+      {
+        timestamp: "1781012410601",
+        model: "claude-opus-4-8-thinking-high",
+        tokenUsage: {
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          cacheWriteTokens: 0,
+          cacheReadTokens: 0,
+          totalCents: 0,
+        },
+      },
+    ]);
+    expect(entries).toHaveLength(1);
+    // opus fallback: $5/M in + $25/M out → $5 + $2.5 = $7.5
+    expect(entries[0].costUSD).toBeCloseTo(7.5, 2);
+  });
+
+  it("keeps billed Cursor cents when present instead of overwriting with estimate", () => {
+    const { entries } = mapCursorEvents([
+      {
+        timestamp: "1781012410601",
+        model: "claude-opus-4-8-thinking-high",
+        tokenUsage: {
+          inputTokens: 1_000_000,
+          outputTokens: 100_000,
+          totalCents: 12.34,
+        },
+      },
+    ]);
+    expect(entries[0].costUSD).toBeCloseTo(0.1234, 4);
+  });
+
   it("skips events without tokenUsage or timestamp", () => {
     expect(mapCursorEvents([{ model: "x" }]).entries).toEqual([]);
     expect(mapCursorEvents([{ tokenUsage: { inputTokens: 5 } }]).entries).toEqual([]);


### PR DESCRIPTION
## Summary
- Cursor's dashboard API returns `totalCents: 0` for subscription/included usage even when token counts are huge, so profiles showed ~$0 Cursor spend next to billions of tokens.
- Prefer billed cents when present; otherwise fall back to `estimateCostUSD` (same path Claude/Codex already use).
- Add a Composer family fallback tier so Cursor's `composer-*` models aren't priced at $0.
- Apply the same billed-or-estimate logic to the tokscale Cursor fallback.

## Test plan
- [ ] `npm test` (263 tests, including new Cursor included-usage cases)
- [ ] Local dry-run: Cursor cost goes from $0 → API-equivalent estimate while billed `totalCents` rows stay unchanged
- [ ] After publish: `npx whoburnedmore` users on Cursor included plans should see non-zero Cursor $ on the profile