### PR TITLE
fix: stop dropping Claude Code usage from the submission payload (#2)

### DIFF
--- a/src/collect.ts
+++ b/src/collect.ts
@@ -18,6 +18,7 @@ import { collectCursor } from "./cursor.js";
 import {
   collectClaudeNative,
   resolveClaudeConfigRoots,
+  NATIVE_READ_BUDGET_MS,
   type NativeCollectResult,
 } from "./native/claude.js";
 import { collectCodexNative } from "./native/codex.js";
@@ -30,6 +31,31 @@ import {
   reconcileProvenance,
   saveProvenanceStore,
 } from "./provenance-store.js";
+
+/**
+ * Sources our OWN native readers cover. ccusage is only ever a fallback for
+ * these (see `selectSourceEntries`), so `collectAll` no longer probes them in
+ * the parallel phase — doing so re-read the very same multi-GB transcript
+ * corpus concurrently with the reader it exists to back up.
+ */
+export const NATIVE_COVERED_SOURCES = new Set(["claude", "codex"]);
+
+/**
+ * Wall-clock cap for one ccusage probe. Generous for the ordinary case: a
+ * source with no data on disk answers in well under a second, so this only ever
+ * bites a source that really is reading a large corpus.
+ */
+export const CCUSAGE_TIMEOUT_MS = 25_000;
+
+/**
+ * Cap for the claude/codex FALLBACK probe. It re-reads the same corpus the
+ * native reader just failed to finish, so it gets the native reader's budget:
+ * a fallback that gives up sooner than the reader it replaces can never rescue
+ * the run it exists for. (With the old shared 25s cap against a 45s reader, a
+ * corpus too big for the reader was by construction too big for the fallback —
+ * and Claude Code vanished from the payload entirely.)
+ */
+export const CCUSAGE_FALLBACK_TIMEOUT_MS = NATIVE_READ_BUDGET_MS;
 
 /** Sources ccusage can read, in the order we probe them. */
 export const SOURCES = [
@@ -346,11 +372,38 @@ export function selectSourceEntries(
   ccusageEntries: DailyUsageEntry[],
   native: { claude: NativeCollectResult; codex: NativeCollectResult },
 ): DailyUsageEntry[] {
-  if (source === "claude" && native.claude.found && native.claude.entries.length > 0)
+  if (source === "claude" && nativeReaderWon(native.claude))
     return native.claude.entries;
-  if (source === "codex" && native.codex.found && native.codex.entries.length > 0)
+  if (source === "codex" && nativeReaderWon(native.codex))
     return native.codex.entries;
   return ccusageEntries;
+}
+
+/**
+ * Did a native reader produce usable entries? When it did, ccusage is not
+ * consulted for that source at all — which is why `collectAll` can decide
+ * whether the fallback probe is needed BEFORE paying for it.
+ */
+export function nativeReaderWon(result: NativeCollectResult): boolean {
+  return result.found && result.entries.length > 0;
+}
+
+/**
+ * The natively-covered sources that still need a ccusage fallback this run —
+ * i.e. the ones whose native reader came back without usable entries (empty
+ * disk, a timeout, or a throw). Returned in SOURCES order so the fallback pass
+ * is deterministic. Everything else is either already covered natively or was
+ * probed in the parallel phase.
+ */
+export function ccusageFallbackSources(native: {
+  claude: NativeCollectResult;
+  codex: NativeCollectResult;
+}): string[] {
+  return SOURCES.filter(
+    (s) =>
+      NATIVE_COVERED_SOURCES.has(s) &&
+      !nativeReaderWon(s === "claude" ? native.claude : native.codex),
+  );
 }
 
 /**
@@ -367,19 +420,45 @@ export function ccusageClaudeEnv(
   return { ...env, CLAUDE_CONFIG_DIR: resolveClaudeConfigRoots(env).join(",") };
 }
 
+/**
+ * Should a failed ccusage probe be retried once?
+ *
+ * execFile rejects on our own timeout (`killed`), an external signal, a spawn
+ * failure (string `code` like ENOENT), or a clean non-zero exit (numeric
+ * `code`). Only a spawn failure or an EXTERNAL kill is worth retrying — a busy
+ * machine or an OOM-killed pass really can succeed the second time.
+ *
+ * Our OWN timeout is NOT retried. It means the corpus doesn't fit the budget,
+ * which is deterministic: the retry burns another full budget of CPU to fail
+ * identically. That doubled cost is not free — it lands on the exact machine
+ * already struggling and starves the native readers running alongside, making
+ * the silent source drop-out this retry exists to prevent MORE likely. A clean
+ * non-zero exit isn't retried either (keeps "not installed" fast).
+ */
+export function isRetryableCcusageFailure(err: unknown): boolean {
+  const e = err as NodeJS.ErrnoException & {
+    killed?: boolean;
+    signal?: string | null;
+  };
+  if (e.killed === true) return false; // our own timeout — deterministic
+  return e.signal != null || typeof e.code === "string";
+}
+
 async function runCcusageOnce(
   cmd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
+  timeoutMs: number = CCUSAGE_TIMEOUT_MS,
 ): Promise<{ json: unknown | null; transient: boolean }> {
   try {
     const { stdout } = await execFileAsync(cmd, args, {
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
-      // A single source shouldn't be able to hang the whole run. 25s is plenty
-      // for a healthy local read; a hung source gets killed and (if transient)
-      // retried once below rather than stalling everything for minutes.
-      timeout: 25_000,
+      // A single source shouldn't be able to hang the whole run: a hung source
+      // gets killed and (if transient) retried once below rather than stalling
+      // everything for minutes. The claude/codex fallback passes a longer cap —
+      // see CCUSAGE_FALLBACK_TIMEOUT_MS.
+      timeout: timeoutMs,
       ...(env ? { env } : {}),
     });
     if (!stdout) return { json: null, transient: false };
@@ -389,14 +468,7 @@ async function runCcusageOnce(
       return { json: null, transient: false };
     }
   } catch (err) {
-    // execFile rejects on timeout (killed by signal), spawn failure (string
-    // `code` like ENOENT), or a clean non-zero exit (numeric `code`). The first
-    // two are transient (a busy machine, an OOM-killed pass) and worth one retry
-    // so a source isn't silently dropped; a clean non-zero exit means the source
-    // genuinely has nothing/errored — don't retry (keeps "not installed" fast).
-    const e = err as NodeJS.ErrnoException & { killed?: boolean; signal?: string | null };
-    const transient = e.killed === true || e.signal != null || typeof e.code === "string";
-    return { json: null, transient };
+    return { json: null, transient: isRetryableCcusageFailure(err) };
   }
 }
 
@@ -404,12 +476,13 @@ async function runCcusage(
   cmd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
+  timeoutMs: number = CCUSAGE_TIMEOUT_MS,
 ): Promise<unknown | null> {
-  const first = await runCcusageOnce(cmd, args, env);
+  const first = await runCcusageOnce(cmd, args, env, timeoutMs);
   if (first.json !== null || !first.transient) return first.json;
   // One retry on a transient failure so a flaky source stays in the report
   // run-to-run (data consistency) rather than dropping out intermittently.
-  return (await runCcusageOnce(cmd, args, env)).json;
+  return (await runCcusageOnce(cmd, args, env, timeoutMs)).json;
 }
 
 /**
@@ -485,14 +558,26 @@ export async function collectAll(onProgress?: ProgressFn): Promise<CollectResult
   );
 
   const sourceTasks = SOURCES.map(async (source) => {
-    // For Claude, force ccusage to scan both config roots (dual-dir hardening);
-    // other sources inherit the ambient environment.
-    const env = source === "claude" ? ccusageClaudeEnv() : undefined;
-    const json = await runCcusage(
-      cmd,
-      [...prefixArgs, source, "daily", "--json", "--offline"],
-      env,
-    );
+    // claude/codex are read by the native readers above; ccusage is only their
+    // FALLBACK, so it is not probed here. Racing it against the reader it backs
+    // up meant two concurrent full passes over the same multi-GB corpus (plus
+    // the attribution scan over a third) — on a heavy machine that contention
+    // pushed the reader past its budget AND killed the 25s fallback, and the
+    // source silently vanished from the payload. The fallback now runs after
+    // this phase, only if it is actually needed. This stage's tick tracks the
+    // native reader instead, so the bar reflects the work really in flight.
+    if (NATIVE_COVERED_SOURCES.has(source)) {
+      await (source === "claude" ? nativeClaudeTask : nativeCodexTask);
+      tick();
+      return { source, mapped: [] as DailyUsageEntry[] };
+    }
+    const json = await runCcusage(cmd, [
+      ...prefixArgs,
+      source,
+      "daily",
+      "--json",
+      "--offline",
+    ]);
     tick();
     return { source, mapped: json ? mapCcusageDaily(source, json) : [] };
   });
@@ -563,13 +648,32 @@ export async function collectAll(onProgress?: ProgressFn): Promise<CollectResult
   ]);
 
   const native = { claude: nativeClaude, codex: nativeCodex };
+
+  // Deferred ccusage fallback for the natively-covered sources: only for the
+  // ones whose native reader produced nothing usable, and only now that the
+  // parallel phase is done, so the fallback gets the machine to itself. It also
+  // runs on the native reader's budget (CCUSAGE_FALLBACK_TIMEOUT_MS) rather than
+  // the short probe cap. Both together are what keep a heavy Claude Code user's
+  // usage in the payload instead of silently dropping it.
+  const fallbacks = new Map<string, DailyUsageEntry[]>();
+  for (const source of ccusageFallbackSources(native)) {
+    const json = await runCcusage(
+      cmd,
+      [...prefixArgs, source, "daily", "--json", "--offline"],
+      // For Claude, force ccusage to scan both config roots (dual-dir hardening).
+      source === "claude" ? ccusageClaudeEnv() : undefined,
+      CCUSAGE_FALLBACK_TIMEOUT_MS,
+    );
+    fallbacks.set(source, json ? mapCcusageDaily(source, json) : []);
+  }
+
   const entries: DailyUsageEntry[] = [];
   const toolsFound: string[] = [];
   // Re-assemble in SOURCES order so the "from claude, codex, …" line stays stable.
   // For claude/codex the native reader's entries win over ccusage's (see
   // selectSourceEntries); every other source keeps ccusage's mapped entries.
   for (const { source, mapped } of sourceResults) {
-    const chosen = selectSourceEntries(source, mapped, native);
+    const chosen = selectSourceEntries(source, fallbacks.get(source) ?? mapped, native);
     if (chosen.length > 0) {
       entries.push(...chosen);
       toolsFound.push(source);

--- a/test/collect.test.ts
+++ b/test/collect.test.ts
@@ -2,17 +2,25 @@ import { describe, expect, it } from "vitest";
 import {
   capByTokens,
   ccusageClaudeEnv,
+  ccusageFallbackSources,
+  CCUSAGE_FALLBACK_TIMEOUT_MS,
+  CCUSAGE_TIMEOUT_MS,
   dedupeBlocks,
   dedupeDaily,
   dedupeSessions,
   isAuthoritativeScan,
+  isRetryableCcusageFailure,
   mapCcusageBlocks,
   mapCcusageDaily,
   mapCcusageSessions,
+  NATIVE_COVERED_SOURCES,
   selectSourceEntries,
 } from "../src/collect.js";
 import type { DailyUsageEntry } from "../src/shared.js";
-import type { NativeCollectResult } from "../src/native/claude.js";
+import {
+  NATIVE_READ_BUDGET_MS,
+  type NativeCollectResult,
+} from "../src/native/claude.js";
 
 const nativeEntry = (tool: string, requestCount: number): DailyUsageEntry => ({
   date: "2026-06-10",
@@ -115,6 +123,70 @@ describe("selectSourceEntries", () => {
     const native = { claude: found([nativeEntry("claude", 1)]), codex: found([nativeEntry("codex", 1)]) };
     const gemini = selectSourceEntries("gemini", [ccEntry("gemini")], native);
     expect(gemini[0].model).toBe("fallback-model");
+  });
+});
+
+describe("ccusageFallbackSources (deferred fallback probing)", () => {
+  // The regression these guard: ccusage used to probe claude/codex in the same
+  // parallel burst as the native readers, so a heavy machine ran two full
+  // passes over the same multi-GB corpus at once. The contention pushed the
+  // readers past their budget AND killed the shorter-capped fallback, and the
+  // source vanished from the payload entirely (issue #2).
+  const winner = { claude: found([nativeEntry("claude", 5)]), codex: found([nativeEntry("codex", 5)]) };
+
+  it("probes nothing when both native readers produced entries", () => {
+    expect(ccusageFallbackSources(winner)).toEqual([]);
+  });
+
+  it("probes only the source whose native reader came back empty", () => {
+    expect(ccusageFallbackSources({ ...winner, claude: notFound })).toEqual(["claude"]);
+    expect(ccusageFallbackSources({ ...winner, codex: notFound })).toEqual(["codex"]);
+  });
+
+  it("probes a source that found files but no usable entries", () => {
+    expect(ccusageFallbackSources({ ...winner, claude: found([]) })).toEqual(["claude"]);
+  });
+
+  it("probes a source whose native reader timed out or threw", () => {
+    const bailed: NativeCollectResult = { entries: [], found: false, filesScanned: 3, timedOut: true };
+    expect(ccusageFallbackSources({ claude: bailed, codex: bailed })).toEqual(["claude", "codex"]);
+  });
+
+  it("never proposes a fallback probe for a source ccusage owns outright", () => {
+    const all = ccusageFallbackSources({ claude: notFound, codex: notFound });
+    expect(all.every((s) => NATIVE_COVERED_SOURCES.has(s))).toBe(true);
+    expect(all).not.toContain("gemini");
+  });
+});
+
+describe("ccusage fallback budget", () => {
+  it("is never shorter than the native reader it stands in for", () => {
+    // A fallback that gives up sooner than the reader it replaces cannot rescue
+    // the run it exists for: a corpus too big for the reader is then by
+    // construction too big for the fallback, and the source is dropped.
+    expect(CCUSAGE_FALLBACK_TIMEOUT_MS).toBeGreaterThanOrEqual(NATIVE_READ_BUDGET_MS);
+    expect(CCUSAGE_FALLBACK_TIMEOUT_MS).toBeGreaterThan(CCUSAGE_TIMEOUT_MS);
+  });
+});
+
+describe("isRetryableCcusageFailure", () => {
+  it("does NOT retry our own timeout", () => {
+    // Deterministic: the corpus doesn't fit the budget, so a retry burns a
+    // second full budget of CPU to fail identically — starving the native
+    // readers running alongside on the very machine already struggling.
+    expect(isRetryableCcusageFailure({ killed: true, signal: "SIGTERM", code: null })).toBe(false);
+  });
+
+  it("retries a spawn failure", () => {
+    expect(isRetryableCcusageFailure({ code: "ENOENT" })).toBe(true);
+  });
+
+  it("retries an external kill (not ours)", () => {
+    expect(isRetryableCcusageFailure({ killed: false, signal: "SIGKILL" })).toBe(true);
+  });
+
+  it("does NOT retry a clean non-zero exit", () => {
+    expect(isRetryableCcusageFailure({ code: 1, signal: null })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #2.

## TL;DR

The cause is **contention, not parsing**. Claude Code rows were never being filtered out — the readers that produce them were being starved by a duplicated pass over the same corpus, and the fallback meant to rescue that case was structurally guaranteed to fail too.

I could reproduce it exactly on a 1.3 GB / 1456-file Claude corpus: `--dry-run` returned **zero** `claude` rows while `ccusage claude daily` read the same logs fine on its own.

## Ruling out the model-list theory

The issue suggests `fable-5` isn't recognised by whoburnedmore's own model list. That turns out not to be it — there is no model allow-list anywhere in the collect path, and `fable-5` already prices correctly (`claude-fable-5` in `pricing-data.generated.ts`, plus a `/fable/i` fallback tier in `pricing.ts`). An unknown model would price to `$0`, never drop the row.

## What's actually happening

`collectAll` fired the ccusage probe for `claude`/`codex` in the **same parallel burst** as our own native readers for those agents. So a run did two concurrent full passes over the same multi-GB corpus — with the attribution scan over a third — plus 13 other ccusage probes and `session`/`blocks`, each ccusage child itself multi-core (~600 % CPU).

Instrumented on the reproduction machine (10 cores, cold cache):

| | alone | inside the parallel phase |
|---|---|---|
| native Claude reader | **10.9 s**, all 1456 files | hit its 45 s budget having read **283** files |
| `ccusage claude daily` | 11.9 s | killed at 25 s |

Once both fail, the source is dropped silently. Two things made that outcome near-inevitable:

1. **The fallback's cap (25 s) was shorter than the reader's budget (45 s).** A corpus too big for the native reader is by construction too big for the fallback it falls back to — the fallback could never rescue the exact case it exists for.
2. **A budget timeout was classified `transient` and retried once with the same budget.** That's deterministic — it fails again — while burning a second full budget of CPU on the machine already starving the readers. `session` and `blocks` each spent 2 × 25 s that way, concurrently with the readers racing their own clock.

This also explains the *"stale Codex entries"* in the title: Codex wasn't stale, it had fallen back to ccusage's 80 rows instead of the native reader's 21 correct ones.

## The fix

- **Defer the claude/codex ccusage probe into a real fallback** — run it after the parallel phase and only when the native reader produced nothing usable, so it never competes with the reader it backs up. Removing the duplicated pass is what actually lets the reader finish.
- **Give that fallback the native reader's budget** (`CCUSAGE_FALLBACK_TIMEOUT_MS`) instead of the short probe cap.
- **Don't retry our own timeout.** Spawn failures and external kills still retry — those genuinely can succeed the second time.

Selection semantics are unchanged: the native reader still wins whenever it has entries, ccusage still backs it up, and every other source is untouched. The progress bar keeps the same stage count; the claude/codex stages now tick on the native reader, which is the work actually in flight.

## Verification

Same machine, cold cache each time:

| | entries | fingerprinted | wall |
|---|---|---|---|
| before | `codex` 80, `cursor` 585, **`claude` 0** | 0 | 53 s |
| after | **`claude` 83** (14.2 B tokens), `codex` 21, `cursor` 585 | **all 104** | 45.5 s |

Two independent cold runs after the fix gave byte-identical row counts, so it's not a lucky race. It's also *faster* than before despite doing strictly more useful work, since the duplicated corpus pass is gone. Note the Codex rows are now the 21 native ones (with `requestCount`) rather than 80 ccusage ones — the fingerprint the anti-fraud check relies on is preserved for both agents instead of lost.

Added tests in `test/collect.test.ts` for the fallback-selection logic, the retry classification, and a regression guard that the fallback budget can never again be shorter than the reader's.

`npm run lint`, `npm run build` and `npm run smoke:package` pass. `npm test` is 270/271 — the one failure, `native-cache.test.ts` › "an appended transcript is re-read", **also fails on a clean `main`** and is unrelated to this change: the fixture's `2026-06-10T18:00:00Z` line lands on the *next* local day for anyone at UTC+7 or east (I'm at UTC+8), splitting one expected day bucket into two. Happy to send that as a separate PR if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
