### PR TITLE
Fix Windows path handling and make the build run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run lint && npm run test && npm run build && npm run smoke:package"
   },
   "dependencies": {
-    "ccusage": "20.0.9",
+    "ccusage": "20.0.19",
     "picocolors": "1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist/index.js"
   ],
   "scripts": {
-    "build": "rm -rf dist && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:ccusage --external:picocolors --external:tokscale",
+    "build": "node scripts/clean.mjs && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:ccusage --external:picocolors --external:tokscale",
     "test": "vitest run",
     "lint": "tsc -p tsconfig.json --noEmit",
     "smoke:package": "node scripts/smoke-package.mjs",

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,3 @@
+import { rm } from "node:fs/promises";
+
+await rm("dist", { recursive: true, force: true });

--- a/src/autosync.ts
+++ b/src/autosync.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, platform } from "node:os";
-import { dirname, join, win32 } from "node:path";
+import { dirname, join, posix, win32 } from "node:path";
 import { defaultConfigDir } from "./config.js";
 
 /**
@@ -254,7 +254,7 @@ export function resolveNpmPath(opts?: {
 
   const sibling = os === "win32"
     ? win32.join(win32.dirname(execPath), "npm.cmd")
-    : join(dirname(execPath), "npm");
+    : posix.join(posix.dirname(execPath), "npm");
   if (check(sibling)) return sibling;
 
   return os === "win32" ? "npm.cmd" : "npm";

--- a/src/native/codex.ts
+++ b/src/native/codex.ts
@@ -16,7 +16,7 @@
  */
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { DailyUsageEntry } from "../shared.js";
 import { estimateCostUSD } from "../pricing.js";
 import { nativeCachePath, readFilesWithCache } from "./file-cache.js";
@@ -243,7 +243,7 @@ function resolveCodexHome(env = process.env): string {
 
 /** Resolve the Codex sessions root (honors CODEX_HOME, default ~/.codex). */
 export function resolveCodexSessionsDir(env = process.env): string {
-  return join(resolveCodexHome(env), "sessions");
+  return resolve(resolveCodexHome(env), "sessions");
 }
 
 /**

--- a/test/native-claude.test.ts
+++ b/test/native-claude.test.ts
@@ -275,6 +275,6 @@ describe("resolveClaudeProjectDirs", () => {
     const dirs = resolveClaudeProjectDirs({
       CLAUDE_CONFIG_DIR: "/a/one, /b/two",
     } as NodeJS.ProcessEnv);
-    expect(dirs).toEqual(["/a/one/projects", "/b/two/projects"]);
+    expect(dirs).toEqual([join("/a/one", "projects"), join("/b/two", "projects")]);
   });
 });

--- a/test/native-codex.test.ts
+++ b/test/native-codex.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import path from "node:path";
 import {
   CODEX_CACHE_VERSION,
   aggregateCodexSessions,
@@ -138,22 +139,24 @@ describe("aggregateCodexSessions", () => {
 
 describe("resolveCodexSessionsDir", () => {
   it("defaults to ~/.codex/sessions and honors CODEX_HOME", () => {
-    expect(resolveCodexSessionsDir({} as NodeJS.ProcessEnv)).toMatch(/\.codex\/sessions$/);
-    expect(resolveCodexSessionsDir({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv)).toBe("/custom/codex/sessions");
+    expect(resolveCodexSessionsDir({} as NodeJS.ProcessEnv)).toMatch(/\.codex[\/\\]sessions$/);
+    expect(
+      resolveCodexSessionsDir({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv),
+    ).toBe(path.resolve("/custom/codex", "sessions"));
   });
 });
 
 describe("resolveCodexSessionsDirs", () => {
   it("covers both the live and the archived rollout roots", () => {
     expect(resolveCodexSessionsDirs({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv)).toEqual([
-      "/custom/codex/sessions",
-      "/custom/codex/archived_sessions",
+      path.join("/custom/codex", "sessions"),
+      path.join("/custom/codex", "archived_sessions"),
     ]);
   });
 
   it("defaults to ~/.codex and keeps the live dir first", () => {
     const dirs = resolveCodexSessionsDirs({} as NodeJS.ProcessEnv);
-    expect(dirs[0]).toMatch(/\.codex\/sessions$/);
-    expect(dirs[1]).toMatch(/\.codex\/archived_sessions$/);
+    expect(dirs[0]).toMatch(/\.codex[\/\\]sessions$/);
+    expect(dirs[1]).toMatch(/\.codex[\/\\]archived_sessions$/);
   });
 });


### PR DESCRIPTION
### Summary
Fixes two Windows compatibility issues.

### Path resolution
- resolveNpmPath emits POSIX paths for non-Windows targets
- resolveCodexSessionsDir resolves CODEX_HOME correctly on Windows
- codex and claude native tests use platform aware assertions

### Build
- `npm run build` failed on Windows because it relied on `rm -rf`, a Unix only command. Replaced it with a small **_node-clean script_** so the build runs everywhere.

### Additional note

```bash
package.json: ccusage is bumped 20.0.9 -> 20.0.19. This is not churn. 

20.0.9 hangs when reading current opencode data, so opencode usage was never detected. 20.0.19 fixes that. 

The version change is required for opencode support to work.
```

### Related PR

- #10  (independent)
